### PR TITLE
Package.json compatible with Windows environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Provides an API layer over Instagram's public API.",
   "main": "app.js",
   "scripts": {
-    "start": "NODE_ENV=prod node app.js",
+    "start": "set NODE_ENV=prod && node app.js",
     "prod": "npm start",
-    "dev": "NODE_ENV=dev node app.js",
+    "dev": "set NODE_ENV=dev && node app.js",
     "test": "echo \"Dummy Tests Pass\""
   },
   "engines": {


### PR DESCRIPTION
Windows environement will fail at `npm run dev` or `npm run start` with the following error : 

```
'NODE_ENV' n’est pas reconnu en tant que commande interne
ou externe, un programme exécutable ou un fichier de commandes.
```

This is the fix.